### PR TITLE
Resolve AmbiguousForeignKeysError by specifying foreign_keys in relationships

### DIFF
--- a/src/blueprints/student/bp_student.py
+++ b/src/blueprints/student/bp_student.py
@@ -32,7 +32,7 @@ def home():
     return render_template('341-form.html')
 
 @student_bp.route('/<int:student_id>/341form')
-def home():
+def form341():
     """Home endpoint
 
     Keyword arguments:

--- a/src/models.py
+++ b/src/models.py
@@ -46,11 +46,11 @@ class Form341(Base):
     datetime: Mapped[dt] = mapped_column(DateTime)
 
     reporting_individual_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
-    reporting_individual: Mapped["User"] = relationship("User")
+    reporting_individual: Mapped["User"] = relationship("User", foreign_keys=[reporting_individual_id])
+
 
     student_id: Mapped[int] = mapped_column(ForeignKey("students.id"))
-    student: Mapped["Student"] = relationship("Student", back_populates="form_341s")
-    
+    student: Mapped["Student"] = relationship("Student", back_populates="form_341s", foreign_keys=[student_id])
 def __init__(self, comment, place, datetime, reporting_individual_id, student_id):
     self.comment = comment 
     self.place = place
@@ -74,10 +74,12 @@ class Student(Base):
     phase: Mapped[int] = mapped_column(Integer(), default=0)
 
     user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
-    user: Mapped["User"] = relationship("User")
-    
+    user: Mapped["User"] = relationship("User", foreign_keys=[user_id])
+
+
     supervisor_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
-    supervisor: Mapped["User"] = relationship("User")
+    supervisor: Mapped["User"] = relationship("User", foreign_keys=[supervisor_id])
+   
 
     form_341s: Mapped["Form341"] = relationship("Form341", back_populates="student")
 


### PR DESCRIPTION
Updated relationships in Student and Form341 models to explicitly define foreign keys. Added foreign_keys argument in Student model to disambiguate user and supervisor references. Modified Form341 model to specify foreign keys for reporting individual and student relationships.